### PR TITLE
Fix dependency configuration of dogapi

### DIFF
--- a/fluent-plugin-datadog_event.gemspec
+++ b/fluent-plugin-datadog_event.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "dogapi"
+  spec.add_runtime_dependency "dogapi"
   spec.add_runtime_dependency "fluentd"
 end


### PR DESCRIPTION
Hi,

I installed this plugin via `fluent-gem` and tried to run this plugin with `td-agent-1.1.17`.

```
$ sudo /etc/init.d/td-agent start
Starting td-agent: /usr/lib64/fluent/ruby/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- dogapi (LoadError)
        from /usr/lib64/fluent/ruby/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-datadog_event-0.1.2/lib/fluent/plugin/out_datadog_event.rb:21:in `initialize'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/plugin.rb:97:in `new'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/plugin.rb:97:in `new_impl'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/plugin.rb:43:in `new_output'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/engine.rb:112:in `block in configure'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/engine.rb:102:in `each'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/engine.rb:102:in `configure'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/engine.rb:76:in `parse_config'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:283:in `run_configure'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:90:in `block in start'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:196:in `call'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:196:in `main_process'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:171:in `block in supervise'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:170:in `fork'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:170:in `supervise'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/supervisor.rb:85:in `start'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/lib/fluent/command/fluentd.rb:141:in `<top (required)>'
        from /usr/lib64/fluent/ruby/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/lib64/fluent/ruby/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.39/bin/fluentd:6:in `<top (required)>'
        from /usr/lib64/fluent/ruby/bin/fluentd:23:in `load'
        from /usr/lib64/fluent/ruby/bin/fluentd:23:in `<top (required)>'
        from /usr/sbin/td-agent:7:in `load'
        from /usr/sbin/td-agent:7:in `<main>'
                                                           [FAILED]
```

After I added runtime dependency to your gemspec, I can run it without any troubles.
It would be nice if you give me your idea. Thanks!